### PR TITLE
Allow trailing spaces in endFencesPattern

### DIFF
--- a/app/assets/javascripts/task_list.coffee
+++ b/app/assets/javascripts/task_list.coffee
@@ -202,7 +202,7 @@ class TaskList
   # Used to skip checkbox markup inside of code fences.
   # http://rubular.com/r/TfCDNsy8x4
   @startFencesPattern: /^`{3}.*$/
-  @endFencesPattern: /^`{3}$/
+  @endFencesPattern: /^`{3}\s*$/
 
   # Used to filter out potential mismatches (items not in lists).
   # http://rubular.com/r/OInl6CiePy


### PR DESCRIPTION
When the closing code fence includes trailing spaces, script doesn't detect the end of it.

For example:
<pre>
```
Hello
``` <- there are trailing spaces
</pre>

I'm not sure about other markdown flavors, but CommonMark and GitHub Flavored Markdown (based on CommonMark though) specs says trailing spaces are ignored. 

https://spec.commonmark.org/0.29/#fenced-code-blocks
https://github.github.com/gfm/#fenced-code-blocks

> The closing code fence may be indented up to three spaces, and may be followed only by spaces, which are ignored.

I don't think there would be a big side effect if it allows trailing spaces🙂